### PR TITLE
Fix setup according to README

### DIFF
--- a/scripts/setup_docker_dev_env
+++ b/scripts/setup_docker_dev_env
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-./setup_config_files
+./scripts/setup_config_files
 
 python manage.py migrate
 


### PR DESCRIPTION
According to the project's documentation, in order to install a Docker-based dev environment the following command must be run:
```
cd diff.blog
docker-compose run web ./scripts/setup_docker_dev_env
```
This does not work because `setup_docker_env` would look for `setup_config_files` in the container's root directory (`code`).